### PR TITLE
fix: Mention of incorrect filename for MacOS cmake build artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cmake --build . --config Release
 
 **Anaconda & M1 users**: please verify that `CMAKE_SYSTEM_PROCESSOR: arm64` after running `cmake -DBUILD_SHARED_LIBS=ON .` — if it detects `x86_64`, edit the `CMakeLists.txt` file under the `# Compile flags` to add `set(CMAKE_SYSTEM_PROCESSOR "arm64")`.
 
-If everything went OK, `librwkv.so` (Linux) or `rwkv.o` (MacOS) file should appear in the base repo folder.
+If everything went OK, `librwkv.so` (Linux) or `librwkv.dylib` (MacOS) file should appear in the base repo folder.
 
 
 ### 3. Download an RWKV model from [Hugging Face](https://huggingface.co/BlinkDL) like [this one](https://huggingface.co/BlinkDL/rwkv-4-pile-169m/blob/main/RWKV-4-Pile-169M-20220807-8023.pth) and convert it into `ggml` format


### PR DESCRIPTION
Executing the cmake build produces `librwkv.dylib` on MacOS (tested on Ventura 13.3.1), not `rwkv.so` anymore as is still mentioned in the README.

Filename `rwkv.so` got renamed to `librwkv.dylib` as seen in https://github.com/saharNooby/rwkv.cpp/commit/77e19980e9a6c8762037fd45623f2388d67c87b1