### PR TITLE
Adding rwkv_eval_array operation

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -597,6 +597,20 @@ bool rwkv_eval(struct rwkv_context * ctx, int32_t token, float * state_in, float
     return true;
 }
 
+bool rwkv_eval_array(struct rwkv_context * ctx, int32_t * token_arr, int n_tokens, float * state_in, float * state_out, float * logits_out) {
+    bool success = true;
+    for (int i = 0; i < n_tokens; i++) {
+        success = success && rwkv_eval(ctx, token_arr[i], state_in, state_out, logits_out);
+        state_in = state_out; // switch to using state_out from here onwards
+
+        // If success fail, abort now
+        if( success == false ) {
+            return false;
+        }
+    }
+    return success;
+}
+
 void rwkv_free(struct rwkv_context * ctx) {
     ctx->model->layers.~vector();
     free(ctx->model);

--- a/rwkv.h
+++ b/rwkv.h
@@ -43,6 +43,16 @@ extern "C" {
     // - logits_out: FP32 buffer of size rwkv_get_logits_buffer_element_count. This buffer will be written to.
     RWKV_API bool rwkv_eval(struct rwkv_context * ctx, int32_t token, float * state_in, float * state_out, float * logits_out);
 
+    // Evaluates the model for multiple token in an array
+    // Returns false on any error. Error messages would be printed to stderr.
+    //
+    // - tokens: next token array
+    // - n_tokens: number of tokens in the token array
+    // - state_in: FP32 buffer of size rwkv_get_state_buffer_element_count; or NULL, if this is a first pass.
+    // - state_out: FP32 buffer of size rwkv_get_state_buffer_element_count. This buffer will be written to.
+    // - logits_out: FP32 buffer of size rwkv_get_logits_buffer_element_count. This buffer will be written to.
+    RWKV_API bool rwkv_eval_array(struct rwkv_context * ctx, int32_t * token_arr, size_t tokens_count, float * state_in, float * state_out, float * logits_out);
+
     // Returns count of FP32 elements in state buffer.
     RWKV_API uint32_t rwkv_get_state_buffer_element_count(struct rwkv_context * ctx);
 


### PR DESCRIPTION
Adding a varient of `rwkv_eval` as `rwkv_eval_array` for array operations.

This is useful for X language bindings, where we can eval a larger context, without switching back and forth between X language and C lang context. (I am currently working on a nodejs binding)

Subsequently, if you do add support for "transformer" mode, this should use the "transformer" mode (i dun see the point to doing so though, for CPU eval)