### PR TITLE
Fix encoding issue when loading prompt data

### DIFF
--- a/rwkv/chat_with_bot.py
+++ b/rwkv/chat_with_bot.py
@@ -44,7 +44,7 @@ args = parser.parse_args()
 
 script_dir: pathlib.Path = pathlib.Path(os.path.abspath(__file__)).parent
 
-with open(script_dir / 'prompt' / f'{LANGUAGE}-{PROMPT_TYPE}.json', 'r', encoding = 'utf8') as json_file:
+with open(script_dir / 'prompt' / f'{LANGUAGE}-{PROMPT_TYPE}.json', 'r', encoding='utf8') as json_file:
     prompt_data = json.load(json_file)
 
     user, bot, separator, init_prompt = prompt_data['user'], prompt_data['bot'], prompt_data['separator'], prompt_data['prompt']

--- a/rwkv/chat_with_bot.py
+++ b/rwkv/chat_with_bot.py
@@ -44,7 +44,7 @@ args = parser.parse_args()
 
 script_dir: pathlib.Path = pathlib.Path(os.path.abspath(__file__)).parent
 
-with open(script_dir / 'prompt' / f'{LANGUAGE}-{PROMPT_TYPE}.json', 'r') as json_file:
+with open(script_dir / 'prompt' / f'{LANGUAGE}-{PROMPT_TYPE}.json', 'r', encoding = 'utf8') as json_file:
     prompt_data = json.load(json_file)
 
     user, bot, separator, init_prompt = prompt_data['user'], prompt_data['bot'], prompt_data['separator'], prompt_data['prompt']


### PR DESCRIPTION
Depending on the localization and language settings of Windows, for example, on Windows 10 when the region is set to China, then Python will read the JSON file in GBK encoding by default when running `rwkv/chat_with_bot.py` (while the encoding of the JSON file is actually UTF-8), resulting in the following error:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 399: illegal multibyte sequence
```

I think it will be better to specify the encoding option when reading prompt data from json.