### PR TITLE
BugFix: fix compile error on macos

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -23,6 +23,9 @@
 #ifdef WIN32
 #define stat64 _stat64
 #define fstat64 _fstat64
+#elif __APPLE__
+#define stat64 stat
+#define fstat64 fstat
 #endif
 
 // --- Error handling ---


### PR DESCRIPTION
FIx error of
```
/Users/york/rwkv.cpp/rwkv.cpp:481:19: error: variable has incomplete type 'struct stat64'
    struct stat64 file_stat;
```
on macos 13.1 M1