### PR TITLE
Allow creating multiple contexts per model

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -476,6 +476,8 @@ struct rwkv_graph {
     std::unique_ptr<struct ggml_cgraph> cgraph;
 };
 
+// An instance of RWKV model loaded into the memory.
+// Can be shared between multiple contexts.
 struct rwkv_instance {
     struct rwkv_model model;
     struct ggml_context * ctx;

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -499,7 +499,7 @@ struct rwkv_instance {
     size_t ffn_key_size;
 };
 
-// An RWKV context for a specific instance.
+// RWKV context for a specific instance.
 // Contains the computation graph and is used for inference.
 struct rwkv_context {
     std::shared_ptr<struct rwkv_instance> instance;

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1021,7 +1021,13 @@ struct rwkv_context * rwkv_init_from_file(const char * file_path, const uint32_t
 }
 
 struct rwkv_context * rwkv_clone_context(struct rwkv_context * ctx, const uint32_t n_threads) {
-    return rwkv_new_context_impl(ctx->instance, n_threads);
+    struct rwkv_context * clone = rwkv_new_context_impl(ctx->instance, n_threads);
+
+    if (clone) {
+        clone->print_errors = ctx->print_errors;
+    }
+
+    return clone;
 }
 
 bool rwkv_gpu_offload_layers(const struct rwkv_context * ctx, const uint32_t n_gpu_layers) {

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -487,6 +487,14 @@ struct rwkv_instance {
     struct rwkv_model model;
     struct rwkv_ggml_guard ctx;
     std::unique_ptr<uint8_t []> scratch;
+
+    // TODO come up with a better solution to estimate "work tensor" size.
+    // The ggml_cgraph allocates a "work tensor" the first time it is used.
+    // Currently, the height of blocks.0.ffn.key.weight is the bottleneck in our implementation of RWKV.
+    // Since it is the largest dimension used in any matrix multiply, it is the size used for the "work tensor".
+    // However, if ggml changes its implementation, or rwkv.cpp changes its own implementation, at any point,
+    // this may become outdated. We need to find a way not to hardcode a specific tensor, but to calculate accurately.
+    // This may come out of a ggml issue: https://github.com/ggerganov/ggml/issues/214
     size_t ffn_key_size;
 };
 

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -481,8 +481,9 @@ struct rwkv_ggml_guard {
     ~rwkv_ggml_guard() { if (ctx) { ggml_free(ctx); } }
 };
 
-// An instance of RWKV model loaded into the memory.
-// Can be shared between multiple contexts.
+// An instance of an RWKV model loaded into memory:
+// Contains all the model weights.
+// Shared by one or more contexts.
 struct rwkv_instance {
     struct rwkv_model model;
     struct rwkv_ggml_guard ctx;
@@ -498,6 +499,8 @@ struct rwkv_instance {
     size_t ffn_key_size;
 };
 
+// An RWKV context for a specific instance.
+// Contains the computation graph and is used for inference.
 struct rwkv_context {
     std::shared_ptr<struct rwkv_instance> instance;
     struct ggml_context * ctx;

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1025,13 +1025,13 @@ struct rwkv_context * rwkv_clone_context(struct rwkv_context * ctx, const uint32
 bool rwkv_gpu_offload_layers(const struct rwkv_context * ctx, const uint32_t n_gpu_layers) {
 #ifdef GGML_USE_CUBLAS
     {
-        size_t n_gpu = std::min(n_gpu_layers, ctx->model.header.n_layer);
+        size_t n_gpu = std::min(n_gpu_layers, ctx->instance->model.header.n_layer);
 
         size_t gpu_layers = ((struct rwkv_context *) ctx)->gpu_layers;
         size_t vram_total = ((struct rwkv_context *) ctx)->vram_total;
 
         for (size_t i = 0; i < n_gpu; i++) {
-            const struct rwkv_layer & layer = ctx->model.layers[i];
+            const struct rwkv_layer & layer = ctx->instance->model.layers[i];
 
             // Use cuBLAS only for heavy matrices; other operations are not supported for GPU at the moment
             ggml_cuda_transform_tensor(layer.att_key); vram_total += ggml_nbytes(layer.att_key);

--- a/rwkv.h
+++ b/rwkv.h
@@ -61,6 +61,10 @@ extern "C" {
         RWKV_ERROR_PARAM_MISSING = 14
     };
 
+    // RWKV context that can be used for inference.
+    // All functions that operate on rwkv_context are thread-safe.
+    // rwkv_context can be sent to different threads between calls to rwkv_eval.
+    // There is no requirement for rwkv_context to be freed on the creating thread.
     struct rwkv_context;
 
     // Sets whether errors are automatically printed to stderr.
@@ -98,6 +102,7 @@ extern "C" {
     RWKV_API bool rwkv_gpu_offload_layers(const struct rwkv_context * ctx, const uint32_t n_gpu_layers);
 
     // Evaluates the model for a single token.
+    // Not thread-safe. For parallel inference, call rwkv_clone_context to create one rwkv_context for each thread.
     // Returns false on any error. Error messages would be printed to stderr.
     // - token: next token index, in range 0 <= token < n_vocab.
     // - state_in: FP32 buffer of size rwkv_get_state_buffer_element_count; or NULL, if this is a first pass.
@@ -112,6 +117,7 @@ extern "C" {
     RWKV_API uint32_t rwkv_get_logits_buffer_element_count(const struct rwkv_context * ctx);
 
     // Frees all allocated memory and the context.
+    // Does not need to be the same thread that created the rwkv_context.
     RWKV_API void rwkv_free(struct rwkv_context * ctx);
 
     // Quantizes FP32 or FP16 model to one of quantized formats.

--- a/rwkv.h
+++ b/rwkv.h
@@ -85,6 +85,12 @@ extern "C" {
     // - n_threads: count of threads to use, must be positive.
     RWKV_API struct rwkv_context * rwkv_init_from_file(const char * model_file_path, const uint32_t n_threads);
 
+    // Creates a new context from an existing one.
+    // This can allow you to run multiple rwkv_eval's in parallel, without having to load a single model multiple times.
+    // Each rwkv_context can have one eval running at a time.
+    // Every rwkv_context must be freed using rwkv_free.
+    RWKV_API struct rwkv_context * rwkv_clone_context(struct rwkv_context * ctx, const uint32_t n_threads);
+
     // Offloads specified layers of context onto GPU using cuBLAS, if it is enabled.
     // If rwkv.cpp was compiled without cuBLAS support, this function is a no-op.
     RWKV_API bool rwkv_gpu_offload_layers(const struct rwkv_context * ctx, const uint32_t n_gpu_layers);

--- a/rwkv.h
+++ b/rwkv.h
@@ -89,6 +89,8 @@ extern "C" {
     // This can allow you to run multiple rwkv_eval's in parallel, without having to load a single model multiple times.
     // Each rwkv_context can have one eval running at a time.
     // Every rwkv_context must be freed using rwkv_free.
+    // - ctx: context to be cloned.
+    // - n_threads: count of threads to use, must be positive.
     RWKV_API struct rwkv_context * rwkv_clone_context(struct rwkv_context * ctx, const uint32_t n_threads);
 
     // Offloads specified layers of context onto GPU using cuBLAS, if it is enabled.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,3 +14,4 @@ file(COPY expected_logits.bin DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 rwkv_add_test(test_ggml_basics.c)
 rwkv_add_test(test_tiny_rwkv.c)
+rwkv_add_test(test_context_cloning.c)

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -1,0 +1,56 @@
+#include <rwkv.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+void main() {
+	struct rwkv_context * ctx = rwkv_init_from_file("tiny-rwkv-660K-FP32.bin", 2);
+
+	if (!ctx) {
+		enum rwkv_error_flags error = rwkv_get_last_error(NULL);
+		fprintf(stderr, "Unexpected error 0x%.8X\n", error);
+		return EXIT_FAILURE;
+	}
+
+	float * state = calloc(rwkv_get_state_buffer_element_count(ctx), sizeof(float));
+	float * logits = calloc(rwkv_get_logits_buffer_element_count(ctx), sizeof(float));
+
+	if (!state || !logits) {
+		fprintf(stderr, "Failed to allocate state/logits\n");
+		return EXIT_FAILURE;
+	}
+
+	// 0xd1 or 209 is space (0x20 or \u0120 in tokenizer)
+	const unsigned char * prompt = "hello\xd1world";
+
+	rwkv_eval(ctx, prompt[0], NULL, state, logits);
+
+	for (const unsigned char * token = prompt + 1; *token != 0; token++) {
+		rwkv_eval(ctx, *token, state, state, logits);
+	}
+
+	float * expected_logits = logits;
+	logits = calloc(rwkv_get_logits_buffer_element_count(ctx), sizeof(float));
+
+	if (!logits) {
+		fprintf(stderr, "Failed to allocate state/logits\n");
+		return EXIT_FAILURE;
+	}
+
+	struct rwkv_context * ctx2 = rwkv_clone_context(ctx, 2);
+
+	rwkv_eval(ctx, prompt[0], NULL, state, logits);
+
+	for (const unsigned char * token = prompt + 1; *token != 0; token++) {
+		rwkv_eval(ctx, *token, state, state, logits);
+	}
+
+	if (memcmp(expected_logits, logits, rwkv_get_logits_buffer_element_count(ctx) * sizeof(float))) {
+		fprintf(stderr, "results not identical :(\n");
+		return EXIT_FAILURE;
+	} else {
+		fprintf(stdout, "Results identical, success!\n");
+		return EXIT_SUCCESS;
+	}
+}

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -51,7 +51,6 @@ void main() {
 		return EXIT_FAILURE;
 	} else {
 		fprintf(stdout, "Results identical, success!\n");
-		return EXIT_SUCCESS;
 	}
 
 	rwkv_free(ctx);
@@ -60,4 +59,6 @@ void main() {
 	free(expected_logits);
 	free(logits);
 	free(state);
+
+	return EXIT_SUCCESS;
 }

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 
-void main() {
+int main() {
 	struct rwkv_context * ctx = rwkv_init_from_file("tiny-rwkv-660K-FP32.bin", 2);
 
 	if (!ctx) {

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -53,4 +53,11 @@ void main() {
 		fprintf(stdout, "Results identical, success!\n");
 		return EXIT_SUCCESS;
 	}
+
+	rwkv_free(ctx);
+	rwkv_free(ctx2);
+
+	free(expected_logits);
+	free(logits);
+	free(state);
 }

--- a/tests/test_tiny_rwkv.c
+++ b/tests/test_tiny_rwkv.c
@@ -28,7 +28,10 @@ void test_model(const char * model_path, const float * expected_logits, const fl
 
     struct rwkv_context * model = rwkv_init_from_file(model_path, N_THREADS);
     enum rwkv_error_flags error = rwkv_get_last_error(NULL);
-    ASSERT(error == 0, "Unexpected error %d", error);
+    ASSERT(model && error == 0, "Unexpected error %d", error);
+    struct rwkv_context * model2 = rwkv_clone_context(model, N_THREADS);
+    enum rwkv_error_flags error2 = rwkv_get_last_error(NULL);
+    ASSERT(model2 && error2 == 0, "Unexpected error2 %d", error2);
 #ifdef GGML_USE_CUBLAS
     ASSERT(rwkv_gpu_offload_layers(model, N_GPU_LAYERS), "Unexpected error %d", rwkv_get_last_error(model));
 #endif
@@ -38,7 +41,9 @@ void test_model(const char * model_path, const float * expected_logits, const fl
     ASSERT(n_vocab == N_VOCAB, "Unexpected n_vocab in the model");
 
     float * state = malloc(sizeof(float) * rwkv_get_state_buffer_element_count(model));
+    float * state2 = malloc(sizeof(float) * rwkv_get_state_buffer_element_count(model2));
     float * logits = malloc(sizeof(float) * n_vocab);
+    float * logits2 = malloc(sizeof(float) * n_vocab);
 
     char * prompt = "\"in";
 
@@ -46,23 +51,31 @@ void test_model(const char * model_path, const float * expected_logits, const fl
 
     for (size_t i = 0; i < prompt_length; i++) {
         rwkv_eval(model, prompt[i], i == 0 ? NULL : state, state, logits);
+        rwkv_eval(model2, prompt[i], i == 0 ? NULL : state2, state2, logits2);
     }
 
     float diff_sum = 0.0F;
+    float diff_sum2 = 0.0F;
 
     for (uint32_t i = 0; i < n_vocab; i++) {
         diff_sum += logits[i] - expected_logits[i];
+        diff_sum2 += logits2[i] - expected_logits[i];
     }
 
     fprintf(stderr, "Difference sum: %f\n", diff_sum);
+    fprintf(stderr, "Difference sum2: %f\n", diff_sum2);
 
     // When something breaks, difference would be way more than 10
     ASSERT(fabsf(diff_sum) <= fabsf(max_diff) + 0.01F, "Too big difference %f, expected no more than %f", (double) diff_sum, (double) max_diff);
+    ASSERT(fabsf(diff_sum2) <= fabsf(max_diff) + 0.01F, "Too big difference2 %f, expected no more than %f", (double) diff_sum2, (double) max_diff);
 
     rwkv_free(model);
+    rwkv_free(model2);
 
     free(state);
+    free(state2);
     free(logits);
+    free(logits2);
 }
 
 int main(void) {


### PR DESCRIPTION
This allows for parallel inference and I am preparing to support sequence mode using a method similar to this (creating a new kind of graph)

Yes it should be perfectly safe to mix multiple ggml contexts like this, I looked into the code and there is no requirement that graphs only have to be created from the current context :3