### PR TITLE
Fix build on non-MSVC compilers for Windows platforms

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -18,7 +18,9 @@
 #define _FILE_OFFSET_BITS 64
 #define RWKV_MAYBE_BREAK
 
-#ifdef _MSC_BUILD
+#include <sys/stat.h>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define stat _stat64
 #define fstat _fstat64
 #define ftell _ftelli64
@@ -29,7 +31,6 @@
 #define RWKV_MAYBE_BREAK __debugbreak()
 #endif
 #else
-#include <sys/stat.h>
 #if !defined(__APPLE__)
 #define ftell ftello
 #define fseek fseeko


### PR DESCRIPTION
@LostRuins was having this issue using mingw to compile rwkv.cpp.

The issue was that mingw doesn't report MSVC defines & doesn't even declare the fstat family of functions unless `sys/stat.h` is included.

So I moved that include out of the Linux specific section and also tried to detect Windows platforms in general rather than only MSVC.

Maybe this would also fix using MSVC on non-windows platforms, idk. (Does MSVC even exist on other platforms?)