### PR TITLE
Phase out very verbose element_count functions

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1397,9 +1397,15 @@ void rwkv_init_state(const struct rwkv_context * ctx, float * state) {
     const size_t layer_size = (size_t) header.n_embed * 5;
     const size_t layer_zero = (size_t) header.n_embed * 4;
     const size_t layers_size = (size_t) header.n_layer * layer_size;
+
     for (size_t start = 0; start < layers_size; start += layer_size) {
-        for (size_t i = 0; i < layer_zero; state[start + i++] = 0.0F);
-        for (size_t i = layer_zero; i < layer_size; state[start + i++] = -1e30F);
+        for (size_t i = 0; i < layer_zero; i++) {
+            state[start + i] = 0.0F;
+        }
+
+        for (size_t i = layer_zero; i < layer_size; i++) {
+            state[start + i] = -1e30F;
+        }
     }
 }
 

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1363,12 +1363,12 @@ bool rwkv_eval_sequence(const struct rwkv_context * ctx, const uint32_t * sequen
 
 // Provided for compatibility
 extern "C" RWKV_API uint32_t rwkv_get_state_buffer_element_count(const struct rwkv_context * ctx) {
-    return rwkv_state_len(ctx);
+    return rwkv_get_state_len(ctx);
 }
 
 // Provided for compatibility
 extern "C" RWKV_API uint32_t rwkv_get_logits_buffer_element_count(const struct rwkv_context * ctx) {
-    return rwkv_logits_len(ctx);
+    return rwkv_get_logits_len(ctx);
 }
 
 size_t rwkv_get_n_vocab(const struct rwkv_context * ctx) {
@@ -1383,12 +1383,12 @@ size_t rwkv_get_n_layer(const struct rwkv_context * ctx) {
     return (size_t) ctx->instance->model.header.n_layer;
 }
 
-size_t rwkv_state_len(const struct rwkv_context * ctx) {
+size_t rwkv_get_state_len(const struct rwkv_context * ctx) {
     const struct rwkv_file_header & header = ctx->instance->model.header;
     return (size_t) header.n_embed * 5 * (size_t) header.n_layer;
 }
 
-size_t rwkv_logits_len(const struct rwkv_context * ctx) {
+size_t rwkv_get_logits_len(const struct rwkv_context * ctx) {
     return (size_t) ctx->instance->model.header.n_vocab;
 }
 

--- a/rwkv.h
+++ b/rwkv.h
@@ -138,7 +138,7 @@ extern "C" {
     // This is the number of elements you'll need to allocate for a call to rwkv_eval, rwkv_eval_sequence, or rwkv_init_state.
     RWKV_API size_t rwkv_get_state_len(const struct rwkv_context * ctx);
 
-    // Returns the number of elements in the logits output of a given model.
+    // Returns the number of float elements in the logits output of a given model.
     // This is currently always identical to n_vocab.
     RWKV_API size_t rwkv_get_logits_len(const struct rwkv_context * ctx);
 

--- a/rwkv.h
+++ b/rwkv.h
@@ -105,9 +105,9 @@ extern "C" {
     // Not thread-safe. For parallel inference, call rwkv_clone_context to create one rwkv_context for each thread.
     // Returns false on any error. Error messages would be printed to stderr.
     // - token: next token index, in range 0 <= token < n_vocab.
-    // - state_in: FP32 buffer of size rwkv_state_len(); or NULL, if this is a first pass.
-    // - state_out: FP32 buffer of size rwkv_state_len(). This buffer will be written to if non-NULL.
-    // - logits_out: FP32 buffer of size rwkv_logits_len(). This buffer will be written to if non-NULL.
+    // - state_in: FP32 buffer of size rwkv_get_state_len(); or NULL, if this is a first pass.
+    // - state_out: FP32 buffer of size rwkv_get_state_len(). This buffer will be written to if non-NULL.
+    // - logits_out: FP32 buffer of size rwkv_get_logits_len(). This buffer will be written to if non-NULL.
     RWKV_API bool rwkv_eval(const struct rwkv_context * ctx, const uint32_t token, const float * state_in, float * state_out, float * logits_out);
 
     // Evaluates the model for a sequence of tokens.
@@ -117,9 +117,9 @@ extern "C" {
     // Not thread-safe. For parallel inference, call rwkv_clone_context to create one rwkv_context for each thread.
     // Returns false on any error. Error messages would be printed to stderr.
     // - sequence_len: number of tokens to read from the array.
-    // - state_in: FP32 buffer of size rwkv_state_len(), or NULL if this is a first pass.
-    // - state_out: FP32 buffer of size rwkv_state_len(). This buffer will be written to if non-NULL.
-    // - logits_out: FP32 buffer of size rwkv_logits_len(). This buffer will be written to if non-NULL.
+    // - state_in: FP32 buffer of size rwkv_get_state_len(), or NULL if this is a first pass.
+    // - state_out: FP32 buffer of size rwkv_get_state_len(). This buffer will be written to if non-NULL.
+    // - logits_out: FP32 buffer of size rwkv_get_logits_len(). This buffer will be written to if non-NULL.
     RWKV_API bool rwkv_eval_sequence(const struct rwkv_context * ctx, const uint32_t * tokens, size_t sequence_len, const float * state_in, float * state_out, float * logits_out);
 
     // Returns the number of tokens in the given model's vocabulary.
@@ -136,16 +136,16 @@ extern "C" {
 
     // Returns the number of float elements in a complete state for the given model.
     // This is the number of elements you'll need to allocate for a call to rwkv_eval, rwkv_eval_sequence, or rwkv_init_state.
-    RWKV_API size_t rwkv_state_len(const struct rwkv_context * ctx);
+    RWKV_API size_t rwkv_get_state_len(const struct rwkv_context * ctx);
 
     // Returns the number of elements in the logits output of a given model.
     // This is currently always identical to n_vocab.
-    RWKV_API size_t rwkv_logits_len(const struct rwkv_context * ctx);
+    RWKV_API size_t rwkv_get_logits_len(const struct rwkv_context * ctx);
 
     // Initializes the given state so that passing it to rwkv_eval or rwkv_eval_sequence would be identical to passing NULL.
     // Useful in cases where tracking the first call to these functions may be annoying or expensive.
     // State must be initialized for behavior to be defined, passing a zeroed state to rwkv.cpp functions will result in NaNs.
-    // - state: FP32 buffer of size rwkv_state_len() to initialize
+    // - state: FP32 buffer of size rwkv_get_state_len() to initialize
     RWKV_API void rwkv_init_state(const struct rwkv_context * ctx, float * state);
 
     // Frees all allocated memory and the context.

--- a/rwkv.h
+++ b/rwkv.h
@@ -105,9 +105,9 @@ extern "C" {
     // Not thread-safe. For parallel inference, call rwkv_clone_context to create one rwkv_context for each thread.
     // Returns false on any error. Error messages would be printed to stderr.
     // - token: next token index, in range 0 <= token < n_vocab.
-    // - state_in: FP32 buffer of size rwkv_get_state_buffer_element_count; or NULL, if this is a first pass.
-    // - state_out: FP32 buffer of size rwkv_get_state_buffer_element_count. This buffer will be written to if non-NULL.
-    // - logits_out: FP32 buffer of size rwkv_get_logits_buffer_element_count. This buffer will be written to if non-NULL.
+    // - state_in: FP32 buffer of size rwkv_state_len(); or NULL, if this is a first pass.
+    // - state_out: FP32 buffer of size rwkv_state_len(). This buffer will be written to if non-NULL.
+    // - logits_out: FP32 buffer of size rwkv_logits_len(). This buffer will be written to if non-NULL.
     RWKV_API bool rwkv_eval(const struct rwkv_context * ctx, const uint32_t token, const float * state_in, float * state_out, float * logits_out);
 
     // Evaluates the model for a sequence of tokens.
@@ -117,16 +117,36 @@ extern "C" {
     // Not thread-safe. For parallel inference, call rwkv_clone_context to create one rwkv_context for each thread.
     // Returns false on any error. Error messages would be printed to stderr.
     // - sequence_len: number of tokens to read from the array.
-    // - state_in: FP32 buffer of size rwkv_get_state_buffer_element_count, or NULL if this is a first pass.
-    // - state_out: FP32 buffer of size rwkv_get_state_buffer_element_count. This buffer will be written to if non-NULL.
-    // - logits_out: FP32 buffer of size rwkv_get_logits_buffer_element_count. This buffer will be written to if non-NULL.
+    // - state_in: FP32 buffer of size rwkv_state_len(), or NULL if this is a first pass.
+    // - state_out: FP32 buffer of size rwkv_state_len(). This buffer will be written to if non-NULL.
+    // - logits_out: FP32 buffer of size rwkv_logits_len(). This buffer will be written to if non-NULL.
     RWKV_API bool rwkv_eval_sequence(const struct rwkv_context * ctx, const uint32_t * tokens, size_t sequence_len, const float * state_in, float * state_out, float * logits_out);
 
-    // Returns count of FP32 elements in state buffer.
-    RWKV_API uint32_t rwkv_get_state_buffer_element_count(const struct rwkv_context * ctx);
+    // Returns the number of tokens in the given model's vocabulary.
+    // Useful for telling legacy RWKV models (n_vocab = 50277) apart from modern World models (n_vocab = 65535).
+    RWKV_API size_t rwkv_get_n_vocab(const struct rwkv_context * ctx);
 
-    // Returns count of FP32 elements in logits buffer.
-    RWKV_API uint32_t rwkv_get_logits_buffer_element_count(const struct rwkv_context * ctx);
+    // Returns the number of elements in the given model's embed weights.
+    // Useful for reading individual fields of a model's hidden state, if desired.
+    RWKV_API size_t rwkv_get_n_embed(const struct rwkv_context * ctx);
+
+    // Returns the number of layers in the given model.
+    // Useful for always offloading the entire model to GPU, if desired.
+    RWKV_API size_t rwkv_get_n_layer(const struct rwkv_context * ctx);
+
+    // Returns the number of float elements in a complete state for the given model.
+    // This is the number of elements you'll need to allocate for a call to rwkv_eval, rwkv_eval_sequence, or rwkv_init_state.
+    RWKV_API size_t rwkv_state_len(const struct rwkv_context * ctx);
+
+    // Returns the number of elements in the logits output of a given model.
+    // This is currently always identical to n_vocab.
+    RWKV_API size_t rwkv_logits_len(const struct rwkv_context * ctx);
+
+    // Initializes the given state so that passing it to rwkv_eval or rwkv_eval_sequence would be identical to passing NULL.
+    // Useful in cases where tracking the first call to these functions may be annoying or expensive.
+    // State must be initialized for behavior to be defined, passing a zeroed state to rwkv.cpp functions will result in NaNs.
+    // - state: FP32 buffer of size rwkv_state_len() to initialize
+    RWKV_API void rwkv_init_state(const struct rwkv_context * ctx, float * state);
 
     // Frees all allocated memory and the context.
     // Does not need to be the same thread that created the rwkv_context.

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -13,8 +13,8 @@ int main() {
 		return EXIT_FAILURE;
 	}
 
-	float * state = calloc(rwkv_get_state_buffer_element_count(ctx), sizeof(float));
-	float * logits = calloc(rwkv_get_logits_buffer_element_count(ctx), sizeof(float));
+	float * state = calloc(rwkv_state_len(ctx), sizeof(float));
+	float * logits = calloc(rwkv_logits_len(ctx), sizeof(float));
 
 	if (!state || !logits) {
 		fprintf(stderr, "Failed to allocate state/logits\n");
@@ -31,7 +31,7 @@ int main() {
 	}
 
 	float * expected_logits = logits;
-	logits = calloc(rwkv_get_logits_buffer_element_count(ctx), sizeof(float));
+	logits = calloc(rwkv_logits_len(ctx), sizeof(float));
 
 	if (!logits) {
 		fprintf(stderr, "Failed to allocate state/logits\n");
@@ -46,7 +46,7 @@ int main() {
 		rwkv_eval(ctx, *token, state, state, logits);
 	}
 
-	if (memcmp(expected_logits, logits, rwkv_get_logits_buffer_element_count(ctx) * sizeof(float))) {
+	if (memcmp(expected_logits, logits, rwkv_logits_len(ctx) * sizeof(float))) {
 		fprintf(stderr, "results not identical :(\n");
 		return EXIT_FAILURE;
 	} else {

--- a/tests/test_context_cloning.c
+++ b/tests/test_context_cloning.c
@@ -13,8 +13,8 @@ int main() {
 		return EXIT_FAILURE;
 	}
 
-	float * state = calloc(rwkv_state_len(ctx), sizeof(float));
-	float * logits = calloc(rwkv_logits_len(ctx), sizeof(float));
+	float * state = calloc(rwkv_get_state_len(ctx), sizeof(float));
+	float * logits = calloc(rwkv_get_logits_len(ctx), sizeof(float));
 
 	if (!state || !logits) {
 		fprintf(stderr, "Failed to allocate state/logits\n");
@@ -31,7 +31,7 @@ int main() {
 	}
 
 	float * expected_logits = logits;
-	logits = calloc(rwkv_logits_len(ctx), sizeof(float));
+	logits = calloc(rwkv_get_logits_len(ctx), sizeof(float));
 
 	if (!logits) {
 		fprintf(stderr, "Failed to allocate state/logits\n");
@@ -46,7 +46,7 @@ int main() {
 		rwkv_eval(ctx, *token, state, state, logits);
 	}
 
-	if (memcmp(expected_logits, logits, rwkv_logits_len(ctx) * sizeof(float))) {
+	if (memcmp(expected_logits, logits, rwkv_get_logits_len(ctx) * sizeof(float))) {
 		fprintf(stderr, "results not identical :(\n");
 		return EXIT_FAILURE;
 	} else {

--- a/tests/test_tiny_rwkv.c
+++ b/tests/test_tiny_rwkv.c
@@ -33,11 +33,11 @@ void test_model(const char * model_path, const float * expected_logits, const fl
     ASSERT(rwkv_gpu_offload_layers(model, N_GPU_LAYERS), "Unexpected error %d", rwkv_get_last_error(model));
 #endif
 
-    uint32_t n_vocab = rwkv_get_logits_buffer_element_count(model);
+    uint32_t n_vocab = rwkv_logits_len(model);
 
     ASSERT(n_vocab == N_VOCAB, "Unexpected n_vocab in the model");
 
-    float * state = malloc(sizeof(float) * rwkv_get_state_buffer_element_count(model));
+    float * state = malloc(sizeof(float) * rwkv_state_len(model));
     float * logits = malloc(sizeof(float) * n_vocab);
 
     char * prompt = "\"in";
@@ -45,8 +45,9 @@ void test_model(const char * model_path, const float * expected_logits, const fl
 
     const size_t prompt_length = strlen(prompt);
 
+    rwkv_init_state(model, state);
     for (size_t i = 0; i < prompt_length; i++) {
-        rwkv_eval(model, prompt[i], i == 0 ? NULL : state, state, logits);
+        rwkv_eval(model, prompt[i], state, state, logits);
     }
 
     float diff_sum = 0.0F;
@@ -60,7 +61,8 @@ void test_model(const char * model_path, const float * expected_logits, const fl
     // When something breaks, difference would be way more than 10
     ASSERT(fabsf(diff_sum) <= fabsf(max_diff) + 0.01F, "Too big difference %f, expected no more than %f", (double) diff_sum, (double) max_diff);
 
-    rwkv_eval_sequence(model, prompt_seq, prompt_length, NULL, state, logits);
+    rwkv_init_state(model, state);
+    rwkv_eval_sequence(model, prompt_seq, prompt_length, state, state, logits);
 
     diff_sum = 0.0F;
 

--- a/tests/test_tiny_rwkv.c
+++ b/tests/test_tiny_rwkv.c
@@ -46,6 +46,7 @@ void test_model(const char * model_path, const float * expected_logits, const fl
     const size_t prompt_length = strlen(prompt);
 
     rwkv_init_state(model, state);
+
     for (size_t i = 0; i < prompt_length; i++) {
         rwkv_eval(model, prompt[i], state, state, logits);
     }

--- a/tests/test_tiny_rwkv.c
+++ b/tests/test_tiny_rwkv.c
@@ -33,11 +33,11 @@ void test_model(const char * model_path, const float * expected_logits, const fl
     ASSERT(rwkv_gpu_offload_layers(model, N_GPU_LAYERS), "Unexpected error %d", rwkv_get_last_error(model));
 #endif
 
-    uint32_t n_vocab = rwkv_logits_len(model);
+    uint32_t n_vocab = rwkv_get_logits_len(model);
 
     ASSERT(n_vocab == N_VOCAB, "Unexpected n_vocab in the model");
 
-    float * state = malloc(sizeof(float) * rwkv_state_len(model));
+    float * state = malloc(sizeof(float) * rwkv_get_state_len(model));
     float * logits = malloc(sizeof(float) * n_vocab);
 
     char * prompt = "\"in";


### PR DESCRIPTION
This could have been done better.

I figured out the secret to declaring backwards-compatibility functions that are no longer in the header file. This doesn't work:

```cpp
RWKV_API extern "C" uint32_t rwkv_get_state_buffer_element_count(const struct rwkv_context * ctx) {
```

This works:

```cpp
extern "C" RWKV_API uint32_t rwkv_get_state_buffer_element_count(const struct rwkv_context * ctx) {
```

So now you know.

For the lulz, I left the python scripts using the old one for now just to show that they work. Let me know if you want those all updated in one go, though I'd prefer to just rework the python scripts completely (I have new bindings that behave a lot better wrt errors).

Anyway, this PR removes `rwkv_get_state_buffer_element_count` and `rwkv_get_logits_buffer_element_count` in favor of `rwkv_get_state_len` and `rwkv_get_logits_len` respectively. It also adds some new functions `rwkv_get_n_vocab`, `rwkv_get_n_embed`, and `rwkv_get_n_layer` for getting those parameters of the model, for people who are interested, and `rwkv_init_state`.

Specifically, `rwkv_get_n_vocab` will assist people automatically picking which tokenizer to use (50277 -> BPE, 65535 -> World), `rwkv_get_n_layer` will assist people in GPU offloading (figuring out how many layers are on/off GPU), `rwkv_get_n_embed` will assist people with poking at the RWKV hidden state, since some people want to do that for e.g. embeddings.

There is also a new `rwkv_init_state` which initializes a state to default / 0 tokens. Useful for people who can't / don't want to track how many times they have called `rwkv_eval` in order to pass null.

All in all this family of functions seems like a very useful and needed addition, and I don't think there'd be any problems with its inclusion.