### PR TITLE
only append to cpu string if not initialized

### DIFF
--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1930,7 +1930,8 @@ bool rwkv_quantize_model_file(const char * in_path, const char * out_path, const
 
 const char * rwkv_get_system_info_string(void) {
     static std::string s;
-    if(s.empty()) {
+
+    if (s.empty()) {
         s  = "";
         s += "AVX="       + std::to_string(ggml_cpu_has_avx())       + " ";
         s += "AVX2="      + std::to_string(ggml_cpu_has_avx2())      + " ";

--- a/rwkv.cpp
+++ b/rwkv.cpp
@@ -1930,20 +1930,21 @@ bool rwkv_quantize_model_file(const char * in_path, const char * out_path, const
 
 const char * rwkv_get_system_info_string(void) {
     static std::string s;
-
-    s  = "";
-    s += "AVX="       + std::to_string(ggml_cpu_has_avx())       + " ";
-    s += "AVX2="      + std::to_string(ggml_cpu_has_avx2())      + " ";
-    s += "AVX512="    + std::to_string(ggml_cpu_has_avx512())    + " ";
-    s += "FMA="       + std::to_string(ggml_cpu_has_fma())       + " ";
-    s += "NEON="      + std::to_string(ggml_cpu_has_neon())      + " ";
-    s += "ARM_FMA="   + std::to_string(ggml_cpu_has_arm_fma())   + " ";
-    s += "F16C="      + std::to_string(ggml_cpu_has_f16c())      + " ";
-    s += "FP16_VA="   + std::to_string(ggml_cpu_has_fp16_va())   + " ";
-    s += "WASM_SIMD=" + std::to_string(ggml_cpu_has_wasm_simd()) + " ";
-    s += "BLAS="      + std::to_string(ggml_cpu_has_blas())      + " ";
-    s += "SSE3="      + std::to_string(ggml_cpu_has_sse3())      + " ";
-    s += "VSX="       + std::to_string(ggml_cpu_has_vsx());
+    if(s.empty()) {
+        s  = "";
+        s += "AVX="       + std::to_string(ggml_cpu_has_avx())       + " ";
+        s += "AVX2="      + std::to_string(ggml_cpu_has_avx2())      + " ";
+        s += "AVX512="    + std::to_string(ggml_cpu_has_avx512())    + " ";
+        s += "FMA="       + std::to_string(ggml_cpu_has_fma())       + " ";
+        s += "NEON="      + std::to_string(ggml_cpu_has_neon())      + " ";
+        s += "ARM_FMA="   + std::to_string(ggml_cpu_has_arm_fma())   + " ";
+        s += "F16C="      + std::to_string(ggml_cpu_has_f16c())      + " ";
+        s += "FP16_VA="   + std::to_string(ggml_cpu_has_fp16_va())   + " ";
+        s += "WASM_SIMD=" + std::to_string(ggml_cpu_has_wasm_simd()) + " ";
+        s += "BLAS="      + std::to_string(ggml_cpu_has_blas())      + " ";
+        s += "SSE3="      + std::to_string(ggml_cpu_has_sse3())      + " ";
+        s += "VSX="       + std::to_string(ggml_cpu_has_vsx());
+    }
 
     return s.c_str();
 }


### PR DESCRIPTION
Hi,
This PR fixes when `rwkv_get_system_info_string()` gets called multiples times. The returned string becomes longer and longer.