### PR TITLE
Fix: Use correct HIPBLAS shared library flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ if (RWKV_HIPBLAS)
                     ${CMAKE_SOURCE_DIR}/ggml/src/ggml-cuda.cu
                     ${CMAKE_SOURCE_DIR}/ggml/src/ggml-cuda.h)
 
-        if (BUILD_SHARED_LIBS)
+        if (RWKV_BUILD_SHARED_LIBRARY)
             set_target_properties(ggml-rocm PROPERTIES POSITION_INDEPENDENT_CODE ON)
         endif()
 


### PR DESCRIPTION
There are no other references to `BUILD_SHARED_LIBS` so I'm assuming this was a mistake. It won't build on Linux at least due to the lack of `-fPIC` causing linking to fail.

This this change, I was able to successful compile and use the GPU with ROCM.