### PR TITLE
Support `pkg-config` and `cmake --install`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ models/*
 /result
 /perplexity
 /embedding
+/rwkv.pc
 
 arm_neon.h
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,3 +452,17 @@ if (NOT RWKV_STANDALONE)
 elseif()
     set_property(TARGET ggml PROPERTY GGML_STANDALONE ON)
 endif()
+
+if (RWKV_BUILD_SHARED_LIBRARY)
+    install(TARGETS rwkv LIBRARY)
+endif()
+
+if (RWKV_STATIC)
+    install(TARGETS rwkv ARCHIVE)
+endif()
+
+if (RWKV_BUILD_SHARED_LIBRARY OR RWKV_STATIC)
+    configure_file(rwkv.pc.in rwkv.pc @ONLY)
+    install(FILES rwkv.pc DESTINATION lib/pkgconfig)
+    install(FILES ${CMAKE_SOURCE_DIR}/rwkv.h DESTINATION include)
+endif()


### PR DESCRIPTION
我修改了 `CMakeLists.txt` 添加安装 `librwkv.so` 的功能（ `make install/cmake --install` ）， 并且支持 `pkg-config`。

使用效果：

```bash
meng@laptop:/tmp$ cat main.c 
#include "rwkv.h"
#include <stdio.h>

int main(void) {
    printf("%s\n", rwkv_get_system_info_string());
    return 0;
}

meng@laptop:/tmp$ echo gcc -std=c11 -o main main.c $(pkg-config --libs rwkv)
gcc -std=c11 -o main main.c -L/usr/local/lib -lrwkv

meng@laptop:/tmp$ gcc -std=c11 -o main main.c $(pkg-config --libs rwkv)
meng@laptop:/tmp$ ./main 
AVX=1 AVX2=1 AVX512=0 FMA=1 NEON=0 ARM_FMA=0 F16C=1 FP16_VA=0 WASM_SIMD=0 BLAS=0 SSE3=1 VSX=0
```

对原有功能无影响。在Ubuntu上构建和安装的情况：

```bash
root@laptop:~/rwkv.cpp# cmake .
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- CMAKE_SYSTEM_PROCESSOR: x86_64
-- x86 detected
-- Configuring done
-- Generating done
-- Build files have been written to: /root/rwkv.cpp
root@laptop:~/rwkv.cpp# cmake --build . --config Release
[  4%] Building C object CMakeFiles/ggml.dir/ggml/src/ggml.c.o
[  9%] Building C object CMakeFiles/ggml.dir/ggml/src/ggml-alloc.c.o
[  9%] Built target ggml
...

Consolidate compiler generated dependencies of target rwkv_quantize
[ 95%] Building C object extras/CMakeFiles/rwkv_quantize.dir/quantize.c.o
[100%] Linking C executable ../bin/rwkv_quantize
[100%] Built target rwkv_quantize
root@laptop:~/rwkv.cpp# cmake --install .
-- Install configuration: "Release"
-- Installing: /usr/local/lib/librwkv.so
-- Installing: /usr/local/lib/pkgconfig/rwkv.pc
-- Installing: /usr/local/include/rwkv.h
root@laptop:~/rwkv.cpp#
```

顺便测试了一下在Windows系统上构建和安装也是可以的：

```bash
$ cmake . -DCMAKE_INSTALL_PREFIX="$(pwd)/in_dir"
-- Building for: Visual Studio 17 2022
-- The C compiler identification is MSVC 19.38.33134.0
-- The CXX compiler identification is MSVC 19.38.33134.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/program/Visual_Studio/2022/BuildTools/VC/Tools/MSVC/14.38.33130/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/my_program/Visual_Studio/2022/BuildTools/VC/Tools/MSVC/14.38.33130/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- CMAKE_SYSTEM_PROCESSOR: AMD64
-- x86 detected
-- Configuring done (11.4s)
-- Generating done (0.1s)
-- Build files have been written to: D:/rwkv.cpp

$ cmake --build . --config Release
适用于 .NET Framework MSBuild 版本 17.8.5+b5265ef37

  1>Checking Build System
  Building Custom Rule D:/rwkv.cpp/CMakeLists.txt
  ...

  Building Custom Rule D:/rwkv.cpp/tests/CMakeLists.txt
  test_quantized_matmul_on_gpu.c
  test_quantized_matmul_on_gpu.vcxproj -> D:\rwkv.cpp\bin\Release\test_quantized_matmul_on_gpu.exe
  Building Custom Rule D:/rwkv.cpp/tests/CMakeLists.txt
  test_tiny_rwkv.c
  test_tiny_rwkv.vcxproj -> D:\rwkv.cpp\bin\Release\test_tiny_rwkv.exe
  Building Custom Rule D:/rwkv.cpp/CMakeLists.txt

$ cmake --install .
-- Install configuration: "Release"
-- Installing: D:/rwkv.cpp/in_dir/lib/rwkv.lib
-- Installing: D:/rwkv.cpp/in_dir/bin/rwkv.dll
-- Installing: D:/rwkv.cpp/in_dir/lib/pkgconfig/rwkv.pc
-- Installing: D:/rwkv.cpp/in_dir/include/rwkv.h
```
